### PR TITLE
Bugfix nagios.php, missing  in function (global)

### DIFF
--- a/nagios.php
+++ b/nagios.php
@@ -23,7 +23,7 @@ $tabhandler['object']['Nagios'] = 'NagiosTabHandler';
 function NagiosTabHandler()
 {
 
- global $nagios_user, $nagios_password, $nagios_url;
+ global $nagios_user, $nagios_password, $nagios_url, $attribute_id;
 
  # Load object data
  assertUIntArg ('object_id', __FUNCTION__);


### PR DESCRIPTION
Plugin will ignore a custom added Nagios hostname, since var is missing in global in NagiosTabHandler()
