### PR TITLE
LinkManagement: add optional port list extension

### DIFF
--- a/LinkManagement/plugins/linkmgmt.php
+++ b/LinkManagement/plugins/linkmgmt.php
@@ -245,7 +245,7 @@ function plugin_linkmgmt_renderObjectPortRow ($port, $is_highlighted)
 				else
 				{
 					// Front-linked only
-					echo '<td>&nbsp;</td><td></td><td></td>';   // End of the row
+					echo '<td>&nbsp;</td><td>&nbsp;</td>';   // End of the row
 				}
 		}
 		else
@@ -260,7 +260,7 @@ function plugin_linkmgmt_renderObjectPortRow ($port, $is_highlighted)
 			}
 			else
 			{
-				echo '<td>&nbsp;</td><td></td><td></td>';   // End of the row
+				echo '<td>&nbsp;</td><td>&nbsp;</td>';   // End of the row
 			}
 		}
 	}
@@ -275,7 +275,7 @@ function plugin_linkmgmt_renderObjectPortRow ($port, $is_highlighted)
 		if ($lc->first != $port['id'])
 		{
 			// Back-linked port without a front-link
-			echo '<td></td>'.
+			echo '<td>&nbsp;</td>'.
 				'<td>'.
 				formatPortLink($lc->ports[$lc->first]['object_id'], $lc->ports[$lc->first]['object_name'],  $lc->ports[$lc->first]['id'], NULL).
 				'</td>' .
@@ -284,7 +284,7 @@ function plugin_linkmgmt_renderObjectPortRow ($port, $is_highlighted)
 		else
 		{
 			// Port without a front or back link
-			echo '<td>&nbsp;</td><td></td><td></td>';   // End of the row
+			echo '<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td>';   // End of the row
 		}
 	}
 


### PR DESCRIPTION
@github138: Maik, here is a contribution from @mahomedh, which adds an option to extend the port list on the object page with the information pulled from LinkManagement data. The performance issue that commit 09712ce had fixed some time ago was made visible by this feature.

I have reviewed these changes, they look OK and have user demand. I am going to commit this within next few days unless you provide an objection.