### PR TITLE
linkmgmt.php: change default image type for GraphViz maps to png

### DIFF
--- a/LinkManagement/plugins/linkmgmt.php
+++ b/LinkManagement/plugins/linkmgmt.php
@@ -1979,7 +1979,7 @@ class lm_Image_GraphViz extends Image_GraphViz {
 		$type = $_REQUEST['type'];
 	}
 	else
-		$type = 'gif';
+		$type = 'png';
 
 	/* highlight port */
 	if(!$hl && isset($_REQUEST['hl_port_id']))


### PR DESCRIPTION
Some distributions of GraphViz don't seem to support GIF image output, resulting in an `ERROR Fetching image data!` message in the browser window.

(With debugging enabled, the plugin reports `dot command failed: Format: "gif" not recognized.`)